### PR TITLE
Fix bug where PoisonedBehavior damage ignored POISON resistance

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -85,8 +85,10 @@ PoisonedBehavior::~PoisonedBehavior( void )
 //-------------------------------------------------------------------------------------------------
 void PoisonedBehavior::onDamage( DamageInfo *damageInfo )
 {
-	if( damageInfo->in.m_damageType == DAMAGE_POISON )
-		startPoisonedEffects( damageInfo );
+	// @bugfix hanfield 01/08/2025 Check m_sourceID to see if we are causing damage. If we are - ignore.
+	if( damageInfo->in.m_damageType == DAMAGE_POISON && 
+		damageInfo->in.m_sourceID != INVALID_ID) 
+		startPoisonedEffects( damageInfo );      
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -118,8 +120,8 @@ UpdateSleepTime PoisonedBehavior::update()
 		DamageInfo damage;
 		damage.in.m_amount = m_poisonDamageAmount;
 		damage.in.m_sourceID = INVALID_ID;
-		damage.in.m_damageType = DAMAGE_UNRESISTABLE; // Not poison, as that will infect us again
-		damage.in.m_damageFXOverride = DAMAGE_POISON; // but this will ensure that the right effect is played
+		damage.in.m_damageType = DAMAGE_POISON; // @bugfix hanfield 01/08/2025 Since we now check for sourceID, this damage will not cause an infinite poison loop
+		damage.in.m_damageFXOverride = DAMAGE_POISON; // Not necessary anymore, but can help to make sure proper FX are used, if template is wonky
 		damage.in.m_deathType = m_deathType;
 		getObject()->attemptDamage( &damage );
 


### PR DESCRIPTION
- In order to prevent an infinite self-poisoning loop, the damage being dealt was set to DAMAGE_UNRESISTABLE.
- Adding a check for the source of the damage prevents us from restarting poison effects, thus we can safely use DAMAGE_POISON damage type once again.